### PR TITLE
Fix typo in excel export preventing analysis to be exportet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Master
 
 [unreleased]
+- bump opensoar to 1.1.2: now support empty callsign
+- fix internal typo in settingsclass
 
 v0.64.0 - 2023-08-25
 - made export more robust when certain attributes not present

--- a/PySoar/exportClass.py
+++ b/PySoar/exportClass.py
@@ -21,8 +21,8 @@ class ExcelExport(object):
 
     def initiate_style_dict(self):
         self.style_dict['text'] = xlwt.easyxf('font: name Times New Roman')
-        self.style_dict['text_bst'] = xlwt.easyxf('font: name Times New Roman, bold on; pattern: pattern solid, fore_colour light_green')
-        self.style_dict['text_wrst'] = xlwt.easyxf('font: name Times New Roman, bold on; pattern: pattern solid, fore_colour rose')
+        self.style_dict['text_best'] = xlwt.easyxf('font: name Times New Roman, bold on; pattern: pattern solid, fore_colour light_green')
+        self.style_dict['text_worst'] = xlwt.easyxf('font: name Times New Roman, bold on; pattern: pattern solid, fore_colour rose')
 
         self.style_dict['number'] = xlwt.easyxf('font: name Times New Roman, bold off', num_format_str='#,##0.00')
         self.style_dict['number_best'] = xlwt.easyxf('font: name Times New Roman, bold on; pattern: pattern solid, fore_colour light_green', num_format_str='#,##0.00')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 xlwt==1.3.0
 pyinstaller==5.9.0
-opensoar==1.1.1
+opensoar==1.1.2
 wxpython==4.2.0  # python <= 3.10
 requests==2.28.2


### PR DESCRIPTION
a typo prevents creating a report. This is fixed with this pull request